### PR TITLE
CDAP-14738 ablity to use py4j library to run python scripts

### DIFF
--- a/src/main/java/co/cask/hydrator/python/transform/Py4jPythonExecutor.java
+++ b/src/main/java/co/cask/hydrator/python/transform/Py4jPythonExecutor.java
@@ -168,14 +168,6 @@ public class Py4jPythonExecutor implements PythonExecutor {
 
   @Override
   public void destroy() {
-    try {
-      if (py4jTransport != null) {
-        py4jTransport.finish();
-      }
-    } catch (Exception e) {
-      LOGGER.warn("Cannot close python process.\n", e);
-    }
-
     if (gatewayServer != null) {
       gatewayServer.shutdown();
     }

--- a/src/main/java/co/cask/hydrator/python/transform/Py4jTransport.java
+++ b/src/main/java/co/cask/hydrator/python/transform/Py4jTransport.java
@@ -40,9 +40,4 @@ public interface Py4jTransport {
    * @param scriptContext context containing information
    */
   void transform(Object record, Emitter<Map> emitter, ScriptContext scriptContext);
-
-  /**
-   * Close connection to jvm
-   */
-  void finish();
 }


### PR DESCRIPTION
In streaming mode or when a job gets killed with a signal destroy phase won't get triggered. That's why we need these changes. They ensure python process waits for java client to disconnect and than finishes the process itself