### PR TITLE
CDAP-14738 ablity to use py4j library to run python scripts. Integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,11 +97,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-data-pipeline</artifactId>
+      <version>${cdap.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+
 
   </dependencies>
 

--- a/src/main/java/co/cask/hydrator/python/transform/PythonEvaluator.java
+++ b/src/main/java/co/cask/hydrator/python/transform/PythonEvaluator.java
@@ -215,8 +215,15 @@ public class PythonEvaluator extends Transform<StructuredRecord, StructuredRecor
     } else {
       pipelineConfigurer.getStageConfigurer().setOutputSchema(pipelineConfigurer.getStageConfigurer().getInputSchema());
     }
-    // try evaluating the script to fail application creation if the script is invalid
-    init(null);
+    // try evaluating the script to fail application creation
+    // if the script is invalid (only possible for interpreted mode)
+    if (config.executionMode.equalsIgnoreCase(EXECUTION_MODE_INTERPRETED)) {
+      try {
+        new JythonPythonExecutor(config).initialize(null);
+      } catch (IOException | InterruptedException e) {
+        throw new RuntimeException("Could not compile script", e);
+      }
+    }
   }
 
   @Override

--- a/src/test/java/co/cask/hydrator/python/transform/BasePythonTransformTest.java
+++ b/src/test/java/co/cask/hydrator/python/transform/BasePythonTransformTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.python.transform;
+
+import co.cask.cdap.api.artifact.ArtifactSummary;
+import co.cask.cdap.api.data.format.StructuredRecord;
+import co.cask.cdap.api.data.schema.Schema;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.common.lang.WeakReferenceDelegatorClassLoader;
+import co.cask.cdap.datapipeline.DataPipelineApp;
+import co.cask.cdap.datapipeline.SmartWorkflow;
+import co.cask.cdap.etl.mock.batch.MockSink;
+import co.cask.cdap.etl.mock.batch.MockSource;
+import co.cask.cdap.etl.mock.test.HydratorTestBase;
+import co.cask.cdap.etl.proto.v2.ETLBatchConfig;
+import co.cask.cdap.etl.proto.v2.ETLPlugin;
+import co.cask.cdap.etl.proto.v2.ETLStage;
+import co.cask.cdap.proto.ProgramRunStatus;
+import co.cask.cdap.proto.artifact.AppRequest;
+import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ArtifactId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.DataSetManager;
+import co.cask.cdap.test.TestConfiguration;
+import co.cask.cdap.test.WorkflowManager;
+import co.cask.hydrator.common.script.ScriptContext;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * Unit tests for our plugins.
+ */
+public abstract class BasePythonTransformTest extends HydratorTestBase {
+
+  private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("python-evaluator", "2.2.0-SNAPSHOT");
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+
+  protected static final Schema SCHEMA = Schema.recordOf(
+    "data",
+    Schema.Field.of("s", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+    Schema.Field.of("i", Schema.nullableOf(Schema.of(Schema.Type.INT))),
+    Schema.Field.of("l", Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+    Schema.Field.of("f", Schema.nullableOf(Schema.of(Schema.Type.FLOAT))),
+    Schema.Field.of("d", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
+    Schema.Field.of("b", Schema.nullableOf(Schema.of(Schema.Type.BOOLEAN))));
+
+  protected static final List<StructuredRecord> INPUT_DEFAULT = ImmutableList.of(
+    StructuredRecord.builder(SCHEMA)
+      .set("s", "ab").set("i", 0).set("l", 0L).set("f", 0f).set("d", 0d).set("b", true).build(),
+    StructuredRecord.builder(SCHEMA)
+      .set("s", "xy").set("i", -10).set("l", -10L).set("f", -10f).set("d", -10d).set("b", true).build(),
+    StructuredRecord.builder(SCHEMA)
+      .set("s", "a").set("i", 10).set("l", 10L).set("f", 10f).set("d", 10d).set("b", false).build(),
+    StructuredRecord.builder(SCHEMA)
+      .set("s", "").set("i", 0).set("l", 0L).set("f", 0f).set("d", 0d).set("b", false).build());
+
+  @BeforeClass
+  public static void setupTestClass() throws Exception {
+    ArtifactId parentArtifact = NamespaceId.DEFAULT.artifact(APP_ARTIFACT.getName(), APP_ARTIFACT.getVersion());
+
+    // add the artifact and mock plugins
+    setupBatchArtifacts(parentArtifact, DataPipelineApp.class);
+
+    // add our plugins artifact with the artifact as its parent.
+    // this will make our plugins available.
+
+    addPluginArtifact(NamespaceId.DEFAULT.artifact("example-plugins", "1.0.0"),
+                      parentArtifact,
+                      ScriptContext.class,
+                      PythonEvaluator.class,
+                      WeakReferenceDelegatorClassLoader.class);
+  }
+
+  @Test
+  public void testPrimitivesDecoded() throws Exception {
+    String script = "def transform(record, emitter, context):\n" +
+      "    emitter.emit(record)\n";
+
+    Map<String, String> properties = ImmutableMap.of("script", script,
+                                                     "executionMode", getExecutionMode(),
+                                                     "pythonBinary", "python");
+
+    List<StructuredRecord> outputRecords = runPythonEvaluatorPipeline(INPUT_DEFAULT, properties);
+
+    Assert.assertEquals(new HashSet<>(outputRecords), new HashSet<>(INPUT_DEFAULT));
+  }
+
+  @Test
+  public void testFilterRecords() throws Exception {
+    String script = "def transform(record, emitter, context):\n" +
+      "  if not record['l']:\n" +
+      "    emitter.emit(record)";
+
+    Map<String, String> properties = ImmutableMap.of("script", script,
+                                                     "executionMode", getExecutionMode(),
+                                                     "pythonBinary", "python");
+
+    List<StructuredRecord> outputRecords = runPythonEvaluatorPipeline(INPUT_DEFAULT, properties);
+
+    List<StructuredRecord> expected = ImmutableList.of(
+      StructuredRecord.builder(SCHEMA)
+        .set("s", "ab").set("i", 0).set("l", 0L).set("f", 0f).set("d", 0d).set("b", true).build(),
+      StructuredRecord.builder(SCHEMA)
+        .set("s", "").set("i", 0).set("l", 0L).set("f", 0f).set("d", 0d).set("b", false).build());
+
+    Assert.assertEquals(new HashSet<>(outputRecords), new HashSet<>(expected));
+  }
+
+  @Test
+  public void testAddRecords() throws Exception {
+    String script = "def transform(record, emitter, context):\n" +
+      "  emitter.emit(record)\n" +
+      "  record['s'] = 'value'\n" +
+      "  emitter.emit(record)";
+
+    Map<String, String> properties = ImmutableMap.of("script", script,
+                                                     "executionMode", getExecutionMode(),
+                                                     "pythonBinary", "python");
+
+    List<StructuredRecord> outputRecords = runPythonEvaluatorPipeline(INPUT_DEFAULT, properties);
+
+    ImmutableList expected = ImmutableList.builder().
+      addAll(INPUT_DEFAULT).
+      add(StructuredRecord.builder(SCHEMA)
+          .set("s", "value").set("i", 0).set("l", 0L).set("f", 0f).set("d", 0d).set("b", true).build()).
+      add(StructuredRecord.builder(SCHEMA)
+          .set("s", "value").set("i", -10).set("l", -10L).set("f", -10f).set("d", -10d).set("b", true).build()).
+      add(StructuredRecord.builder(SCHEMA)
+          .set("s", "value").set("i", 10).set("l", 10L).set("f", 10f).set("d", 10d).set("b", false).build()).
+      add(StructuredRecord.builder(SCHEMA)
+          .set("s", "value").set("i", 0).set("l", 0L).set("f", 0f).set("d", 0d).set("b", false).build()).
+      build();
+
+    Assert.assertEquals(new HashSet<>(outputRecords), new HashSet<StructuredRecord>(expected));
+  }
+
+  @Test
+  public void testModifyRecords() throws Exception {
+    String script = "def transform(record, emitter, context):\n" +
+      "  record['i'] *= 2\n" +
+      "  emitter.emit(record)";
+
+    Map<String, String> properties = ImmutableMap.of("script", script,
+                                                     "executionMode", getExecutionMode(),
+                                                     "pythonBinary", "python");
+
+    List<StructuredRecord> outputRecords = runPythonEvaluatorPipeline(INPUT_DEFAULT, properties);
+
+    List<StructuredRecord> expected = ImmutableList.of(
+      StructuredRecord.builder(SCHEMA)
+        .set("s", "ab").set("i", 0).set("l", 0L).set("f", 0f).set("d", 0d).set("b", true).build(),
+      StructuredRecord.builder(SCHEMA)
+        .set("s", "xy").set("i", -20).set("l", -10L).set("f", -10f).set("d", -10d).set("b", true).build(),
+      StructuredRecord.builder(SCHEMA)
+        .set("s", "a").set("i", 20).set("l", 10L).set("f", 10f).set("d", 10d).set("b", false).build(),
+      StructuredRecord.builder(SCHEMA)
+        .set("s", "").set("i", 0).set("l", 0L).set("f", 0f).set("d", 0d).set("b", false).build());
+
+    Assert.assertEquals(new HashSet<>(outputRecords), new HashSet<>(expected));
+  }
+
+  @Test
+  public void testContext() throws Exception {
+    String script = "def transform(record, emitter, context):\n" +
+      "  context.getLogger().debug('outputing from python code!')\n" +
+      "  context.getMetrics().count('some_metric', 1)\n" +
+      "  emitter.emit(record)";
+
+    Map<String, String> properties = ImmutableMap.of("script", script,
+                                                     "executionMode", getExecutionMode(),
+                                                     "pythonBinary", "python");
+
+    List<StructuredRecord> outputRecords = runPythonEvaluatorPipeline(INPUT_DEFAULT, properties);
+
+    Assert.assertEquals(new HashSet<>(outputRecords), new HashSet<>(INPUT_DEFAULT));
+  }
+
+  protected abstract String getExecutionMode();
+
+  protected List<StructuredRecord> runPythonEvaluatorPipeline(List<StructuredRecord> input,
+                                                            Map<String, String> pythonEvaluatorProperties)
+    throws Exception {
+    String inputName = "input" + UUID.randomUUID().toString();
+    String outputName = "output" + UUID.randomUUID().toString();
+
+    // create the pipeline config
+    ETLBatchConfig pipelineConfig = ETLBatchConfig.builder("* * * * *")
+      .addStage(new ETLStage("source", MockSource.getPlugin(inputName, SCHEMA)))
+      .addStage(new ETLStage("sink", MockSink.getPlugin(outputName)))
+      .addStage(new ETLStage("fieldStats", new ETLPlugin("PythonEvaluator", "transform",
+                                                         pythonEvaluatorProperties)))
+      .addConnection("source", "fieldStats")
+      .addConnection("fieldStats", "sink")
+      .build();
+
+    // create the pipeline
+    ApplicationId pipelineId = NamespaceId.DEFAULT.app("testPipeline" + UUID.randomUUID().toString());
+    ApplicationManager appManager = deployApplication(pipelineId, new AppRequest<>(APP_ARTIFACT, pipelineConfig));
+
+    DataSetManager<Table> inputManager = getDataset(inputName);
+    MockSource.writeInput(inputManager, input);
+
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 30, TimeUnit.SECONDS);
+
+    DataSetManager<Table> outputManager = getDataset(outputName);
+    List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
+
+    return outputRecords;
+  }
+}

--- a/src/test/java/co/cask/hydrator/python/transform/PythonTransformInterpretedTest.java
+++ b/src/test/java/co/cask/hydrator/python/transform/PythonTransformInterpretedTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.python.transform;
+
+public class PythonTransformInterpretedTest extends BasePythonTransformTest {
+  protected String getExecutionMode() {
+    return "Interpreted";
+  }
+}

--- a/src/test/java/co/cask/hydrator/python/transform/PythonTransformNativeTest.java
+++ b/src/test/java/co/cask/hydrator/python/transform/PythonTransformNativeTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.hydrator.python.transform;
+
+import co.cask.cdap.api.data.format.StructuredRecord;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+public class PythonTransformNativeTest extends BasePythonTransformTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  protected String getExecutionMode() {
+    return "Native";
+  }
+
+  @Test
+  public void testImportThirdPartyLibrary() throws Exception {
+    File tempPythonFile = temporaryFolder.newFile("pythonevaluator_test_lib.py");
+    String folderPath = temporaryFolder.getRoot().getPath();
+
+    try (PrintWriter out = new PrintWriter(tempPythonFile)) {
+      out.write("def emit_with_print(emitter, record):\n" +
+                  "  print \"emitting...\"\n" +
+                  "  emitter.emit(record)");
+    }
+
+    String script = "from pythonevaluator_test_lib import emit_with_print\n" +
+      "def transform(record, emitter, context):\n" +
+      "  emit_with_print(emitter, record)\n";
+
+    Map<String, String> properties = ImmutableMap.of("script", script,
+                                                     "executionMode", getExecutionMode(),
+                                                     "pythonBinary", "python",
+                                                     "pythonPath", folderPath);
+
+    List<StructuredRecord> outputRecords = runPythonEvaluatorPipeline(INPUT_DEFAULT, properties);
+
+    Assert.assertEquals(new HashSet<>(outputRecords), new HashSet<>(INPUT_DEFAULT));
+  }
+}


### PR DESCRIPTION
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
parallel='none', perCoreThreadCount=true, threadCount=2, useUnlimitedThreads=false
Running co.cask.hydrator.python.transform.PythonTransformInterpretedTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 46.355 sec
testModifyRecords(co.cask.hydrator.python.transform.PythonTransformInterpretedTest)  Time elapsed: 9.84 sec
testAddRecords(co.cask.hydrator.python.transform.PythonTransformInterpretedTest)  Time elapsed: 8.051 sec
testFilterRecords(co.cask.hydrator.python.transform.PythonTransformInterpretedTest)  Time elapsed: 7.224 sec
testPrimitivesDecodedNative(co.cask.hydrator.python.transform.PythonTransformInterpretedTest)  Time elapsed: 7.457 sec
testContext(co.cask.hydrator.python.transform.PythonTransformInterpretedTest)  Time elapsed: 8.376 sec
testImportThirdPartyLibrary(co.cask.hydrator.python.transform.PythonTransformInterpretedTest)  Time elapsed: 0 sec
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
parallel='none', perCoreThreadCount=true, threadCount=2, useUnlimitedThreads=false
Running co.cask.hydrator.python.transform.PythonTransformNativeTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 85.146 sec
testModifyRecords(co.cask.hydrator.python.transform.PythonTransformNativeTest)  Time elapsed: 14.686 sec
testAddRecords(co.cask.hydrator.python.transform.PythonTransformNativeTest)  Time elapsed: 13.174 sec
testFilterRecords(co.cask.hydrator.python.transform.PythonTransformNativeTest)  Time elapsed: 13.462 sec
testPrimitivesDecodedNative(co.cask.hydrator.python.transform.PythonTransformNativeTest)  Time elapsed: 13.274 sec
testContext(co.cask.hydrator.python.transform.PythonTransformNativeTest)  Time elapsed: 13.274 sec
testImportThirdPartyLibrary(co.cask.hydrator.python.transform.PythonTransformNativeTest)  Time elapsed: 13.116 sec
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
parallel='none', perCoreThreadCount=true, threadCount=2, useUnlimitedThreads=false
Running co.cask.hydrator.python.transform.PythonEvaluatorTest
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.105 sec
testArguments(co.cask.hydrator.python.transform.PythonEvaluatorTest)  Time elapsed: 1.02 sec
testSchemaValidation(co.cask.hydrator.python.transform.PythonEvaluatorTest)  Time elapsed: 0.012 sec
testDecodingSimpleTypes(co.cask.hydrator.python.transform.PythonEvaluatorTest)  Time elapsed: 0.007 sec
testScriptCompilationValidation(co.cask.hydrator.python.transform.PythonEvaluatorTest)  Time elapsed: 0.002 sec
testDropAndRename(co.cask.hydrator.python.transform.PythonEvaluatorTest)  Time elapsed: 0.005 sec
testComplex(co.cask.hydrator.python.transform.PythonEvaluatorTest)  Time elapsed: 0.028 sec
testNewOutputEmit(co.cask.hydrator.python.transform.PythonEvaluatorTest)  Time elapsed: 0.003 sec
testEmitError(co.cask.hydrator.python.transform.PythonEvaluatorTest)  Time elapsed: 0.011 sec
testSimple(co.cask.hydrator.python.transform.PythonEvaluatorTest)  Time elapsed: 0.017 sec

Results :

Tests run: 21, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:00 min
[INFO] Finished at: 2019-02-16T17:55:49+02:00
[INFO] ------------------------------------------------------------------------